### PR TITLE
[FIX] Migrate sale_purchase_count to v13

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -8,7 +8,7 @@ manifest_required_authors=Graeme Gellatly,Open For Small Business Ltd
 manifest_required_keys=license
 manifest_deprecated_keys=description,active
 license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
-valid_odoo_versions=12.0
+valid_odoo_versions=13.0
 
 [MESSAGES CONTROL]
 disable=all

--- a/.pylintrc-mandatory
+++ b/.pylintrc-mandatory
@@ -8,7 +8,7 @@ manifest_required_authors=Graeme Gellatly,Open For Small Business Ltd
 manifest_required_keys=license
 manifest_deprecated_keys=description,active
 license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
-valid_odoo_versions=12.0
+valid_odoo_versions=13.0
 
 [MESSAGES CONTROL]
 disable=all

--- a/sale_purchase_count/README.rst
+++ b/sale_purchase_count/README.rst
@@ -6,8 +6,9 @@
 Sale Purchase Count
 ===================
 
-Links MRP with sales, enabling
+Links purchase order with sales, enabling
 
+* Display the number of purchase order(s) in each sale order
 * Open linked purchases from sale.
 
 Installation

--- a/sale_purchase_count/__manifest__.py
+++ b/sale_purchase_count/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Sale Purchase Count",
     "summary": "View MTO purchases from sales order",
-    "version": "12.0.1.1.0",
+    "version": "13.0.1.1.0",
     "license": "AGPL-3",
     "author": "Open For Small Business Ltd",
     "website": "https://o4sb.com",

--- a/sale_purchase_count/models/sale_order.py
+++ b/sale_purchase_count/models/sale_order.py
@@ -1,7 +1,7 @@
 # Copyright 2017 Graeme Gellatly
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class SaleOrder(models.Model):
@@ -12,7 +12,6 @@ class SaleOrder(models.Model):
         string="Purchase Orders", compute="_compute_purchase_ids"
     )
 
-    @api.multi
     def _compute_purchase_ids(self):
         Purchase = self.env["purchase.order"]
         for order in self:
@@ -20,7 +19,6 @@ class SaleOrder(models.Model):
                 [("origin", "ilike", order.name)]
             )
 
-    @api.multi
     def action_view_purchase_orders(self):
         """
         This function returns an action that display existing purchase orders


### PR DESCRIPTION
Changes:
* remove @api.multi
* fix README
* change valid_odoo_versions to 13.0 in .pylintrc and .pylintrc

Potential Future Change:
* May deprecate this module as the function seems has been covered in sale_purchase module.
  Need to investigate the problem of purchase_order_count in sale_purchase module does not working properly