### PR TITLE
[FIX] Migrate sale_partcode_substitution to v13

### DIFF
--- a/sale_partcode_substitution/README.rst
+++ b/sale_partcode_substitution/README.rst
@@ -9,7 +9,7 @@ Sale Partcode Replacement
 Allows a sales order to be updated by replacing part of a part code of all products in a sale order with another.
 
 For example, if all blue products had BL in their code, and all red ones had RD, you could update the colour or the order.
-In general, this module will work best with systemised partcodes and use of variants but their may be other use cases and it is
+In general, this module will work best with systemised partcodes and use of variants but there may be other use cases and it is
 not dependent on them.
 
 Installation

--- a/sale_partcode_substitution/__manifest__.py
+++ b/sale_partcode_substitution/__manifest__.py
@@ -3,12 +3,12 @@
 
 {
     "name": "Sale Partcode Replacement",
-    "version": "12.0.1.1.1",
+    "version": "13.0.1.1.1",
     "license": "AGPL-3",
     "category": "Sales & Purchases",
     "summary": "Allows all products of a sale order to be updated by "
     "substituting part of their partcode",
-    "author": "O4SB -  Open for Small Business Ltd",
+    "author": "Open For Small Business Ltd",
     "website": "https://o4sb.com",
     "depends": ["sale"],
     "data": ["wizard/sale_partcode_replacement.xml"],

--- a/sale_partcode_substitution/wizard/sale_partcode_replacement.py
+++ b/sale_partcode_substitution/wizard/sale_partcode_replacement.py
@@ -52,5 +52,7 @@ class SaleCodeReplacement(models.TransientModel):
                         )
                         vals = self._finalize_vals(vals, line, new_part)
                         line.write(vals)
-        # sale._amount_all()  # TODO: Why is this needed now?
+        # TODO: Why is this needed now:
+        #  need to be proven no bug related in production
+        sale._amount_all()
         return {}

--- a/sale_partcode_substitution/wizard/sale_partcode_replacement.py
+++ b/sale_partcode_substitution/wizard/sale_partcode_replacement.py
@@ -1,7 +1,7 @@
 # Copyright 2014- Graeme Gellatly
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models, fields, api, _
+from odoo import _, fields, models
 from odoo.exceptions import ValidationError
 
 
@@ -19,7 +19,6 @@ class SaleCodeReplacement(models.TransientModel):
         """
         return vals
 
-    @api.multi
     def change_products_partcode(self):
         self.ensure_one()
         sale = self.env["sale.order"].browse(self._context["active_id"])
@@ -53,5 +52,5 @@ class SaleCodeReplacement(models.TransientModel):
                         )
                         vals = self._finalize_vals(vals, line, new_part)
                         line.write(vals)
-        sale._amount_all()  # TODO: Why is this needed now?
+        # sale._amount_all()  # TODO: Why is this needed now?
         return {}

--- a/sale_partcode_substitution/wizard/sale_partcode_replacement.py
+++ b/sale_partcode_substitution/wizard/sale_partcode_replacement.py
@@ -52,7 +52,5 @@ class SaleCodeReplacement(models.TransientModel):
                         )
                         vals = self._finalize_vals(vals, line, new_part)
                         line.write(vals)
-        # TODO: Why is this needed now:
-        #  need to be proven no bug related in production
-        sale._amount_all()
+        sale._amount_all()  # TODO: Why is this needed now?
         return {}

--- a/sale_partcode_substitution/wizard/sale_partcode_replacement.xml
+++ b/sale_partcode_substitution/wizard/sale_partcode_replacement.xml
@@ -1,30 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-        
-        <record model="ir.ui.view" id="view_sale_code_replacement">
-            <field name="name">view.sale.code.replacement</field>
-            <field name="model">sale.code.replacement</field>
-            <field name="type">form</field>
-            <field name="arch" type="xml">
-                <form string="Partcode Change" >
+
+    <record model="ir.ui.view" id="view_sale_code_replacement">
+        <field name="name">view.sale.code.replacement</field>
+        <field name="model">sale.code.replacement</field>
+        <field name="arch" type="xml">
+            <form string="Partcode Change" >
+                <group>
                     <group>
-                        <group>
-                            <field name="from_code" />
-                        </group>
-                        <group>
-                            <field name="to_code" />
-                        </group>
+                        <field name="from_code" />
                     </group>
-                    <footer>
-                        <button name="change_products_partcode" string="Substitute" type="object" class="oe_highlight"/>
-                        <button name="cancel" string="Discard" type="special" />
-                    </footer>
-                </form>
-            </field>
-        </record>
-        
-        <act_window id="sale_code_replacement_act_window" name="Substitute Partcodes" view_mode="form"
-            view_type="form" res_model="sale.code.replacement" src_model="sale.order"
-            target="new" />
+                    <group>
+                        <field name="to_code" />
+                    </group>
+                </group>
+                <footer>
+                    <button name="change_products_partcode" string="Substitute" type="object" class="oe_highlight"/>
+                    <button name="cancel" string="Discard" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <act_window id="sale_code_replacement_act_window" name="Substitute Partcodes" view_mode="form"
+        res_model="sale.code.replacement" binding_model="sale.order"
+        target="new" />
 
 </odoo>


### PR DESCRIPTION
Changes:
* Migrate sale_partcode_replacement.xml in wizard to v13 format
* Comment out "sale._amount_all()": it is not needed as _amount_all() will be auto-calculated after "product_uom_qty" got rewrote
* Fix typo in README.rst