### PR TITLE
[FIX] Migrate product_no_translation to v13

### DIFF
--- a/product_no_translation/__manifest__.py
+++ b/product_no_translation/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Product No Translation",
     "summary": """
         Make product related fields non translatable""",
-    "version": "12.0.1.0.0",
+    "version": "13.0.1.0.0",
     "license": "AGPL-3",
     "author": "Graeme Gellatly",
     "website": "https://o4sb.com",


### PR DESCRIPTION
Potential Future Change:
* In v13 "product.category" module, var "name" doesn't have "translate" param, then "name = fields.Char(translate=False)" may not be necessary.