### PR TITLE
[MIG] automated_action_report_print to v13.0

### DIFF
--- a/automated_action_report_print/__manifest__.py
+++ b/automated_action_report_print/__manifest__.py
@@ -1,8 +1,9 @@
 # noinspection PyStatementEffect
 {
     "name": "Automatic Print Rules",
-    "version": "12.0.1.0.0",
-    "author": "O4SB",
+    "version": "13.0.1.0.0",
+    "author": "Open For Small Business Ltd",
+    "license": "AGPL-3",
     "website": "https://o4sb.com",
     "depends": ["base_report_to_printer", "base_automation"],
     "summary": "This module allows to select printer based on properties of "

--- a/automated_action_report_print/models/ir_actions_report.py
+++ b/automated_action_report_print/models/ir_actions_report.py
@@ -1,5 +1,4 @@
-from odoo import models, fields, api, _
-from odoo import exceptions
+from odoo import _, api, exceptions, fields, models
 
 
 class IrActionsReport(models.Model):
@@ -21,7 +20,6 @@ class IrActionsReport(models.Model):
         comodel_name="ir.model", compute="_compute_model_id", store=True
     )
 
-    @api.multi
     def print_document_auto(self, record_ids, behaviour=None, data=None):
         behaviour = behaviour or self.behaviour()
         document, doc_format = self.with_context(
@@ -34,7 +32,6 @@ class IrActionsReport(models.Model):
             self, document, doc_format=self.report_type, **behaviour
         )
 
-    @api.multi
     def behaviour(self):
         if self._context.get("behaviour"):
             return {self: self._context["behaviour"]}

--- a/automated_action_report_print/models/ir_actions_server.py
+++ b/automated_action_report_print/models/ir_actions_server.py
@@ -1,6 +1,6 @@
-from odoo import models, fields, api, _
-from odoo.tools.safe_eval import safe_eval
+from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.tools.safe_eval import safe_eval
 
 
 class IrActionsServer(models.Model):
@@ -51,7 +51,6 @@ class IrActionsServer(models.Model):
         )
         return False
 
-    @api.multi
     def print_behaviour(self):
         self.ensure_one()
         if self.print_action_type == "report":


### PR DESCRIPTION
[Removed] References to api.multi

[Potential Conflicts] in report-print-send
Could not set field system_name in printing_tray.py required to create tray.
Could not set field server_id in printing_printer.py requried to create printer.