### PR TITLE
[MIG] Migrate account_invoice_cutoff_policy to v13

### DIFF
--- a/account_invoice_cutoff_policy/__manifest__.py
+++ b/account_invoice_cutoff_policy/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Customer Invoicing Cutoff Policy",
     "summary": "Specify customer specific invocing cutoff policies",
-    "version": "12.0.1.1.0",
+    "version": "13.0.1.1.0",
     "license": "AGPL-3",
     "author": "Open For Small Business Ltd",
     "website": "https://o4sb.com",

--- a/account_invoice_cutoff_policy/models/account_invoice.py
+++ b/account_invoice_cutoff_policy/models/account_invoice.py
@@ -15,13 +15,14 @@ class AccountInvoice(models.Model):
         """
         return self.commercial_partner_id
 
-    @api.onchange("payment_term_id", "date_invoice")
+    @api.onchange("invoice_date")
     def _onchange_invoice_date(self):
         """
         Extends the onchange to assign the invoice date based on the partners
         invoicing policy
         """
-        date_invoice = self.date_invoice
-        if date_invoice and self.type.startswith("out_"):
-            self.date_invoice = self._get_invoice_partner()._get_lock_date(date_invoice)
+
+        invoice_date = self.invoice_date
+        if invoice_date and self.type.startswith("out_"):
+            self.invoice_date = self._get_invoice_partner()._get_lock_date(invoice_date)
         return super()._onchange_invoice_date()

--- a/account_invoice_cutoff_policy/models/account_invoice.py
+++ b/account_invoice_cutoff_policy/models/account_invoice.py
@@ -5,9 +5,8 @@ from odoo import api, models
 
 
 class AccountInvoice(models.Model):
-    _inherit = "account.invoice"
+    _inherit = "account.move"
 
-    @api.multi
     def _get_invoice_partner(self):
         """
         Hook method for extensibility to determine which partner should be used

--- a/account_invoice_cutoff_policy/models/account_invoice.py
+++ b/account_invoice_cutoff_policy/models/account_invoice.py
@@ -16,7 +16,7 @@ class AccountInvoice(models.Model):
         return self.commercial_partner_id
 
     @api.onchange("payment_term_id", "date_invoice")
-    def _onchange_payment_term_date_invoice(self):
+    def _onchange_invoice_date(self):
         """
         Extends the onchange to assign the invoice date based on the partners
         invoicing policy
@@ -24,4 +24,4 @@ class AccountInvoice(models.Model):
         date_invoice = self.date_invoice
         if date_invoice and self.type.startswith("out_"):
             self.date_invoice = self._get_invoice_partner()._get_lock_date(date_invoice)
-        return super()._onchange_payment_term_date_invoice()
+        return super()._onchange_invoice_date()

--- a/account_invoice_cutoff_policy/models/res_partner.py
+++ b/account_invoice_cutoff_policy/models/res_partner.py
@@ -18,14 +18,12 @@ class ResPartner(models.Model):
         [("date", "transaction date"), ("eom", "end of month following transaction")]
     )
 
-    @api.multi
     def _get_new_invoice_date(self, today):
         if self.cutoff_type == "eom":
             return today + relativedelta(day=1)
         else:
             return today
 
-    @api.multi
     def _get_lock_date(self, date_invoice):
         for partner in self:
             if not partner.enforce_cutoff:

--- a/account_invoice_cutoff_policy/models/res_partner.py
+++ b/account_invoice_cutoff_policy/models/res_partner.py
@@ -24,12 +24,12 @@ class ResPartner(models.Model):
         else:
             return today
 
-    def _get_lock_date(self, date_invoice):
+    def _get_lock_date(self, invoice_date):
         for partner in self:
             if not partner.enforce_cutoff:
                 continue
             today = fields.Date.context_today(partner)
-            transaction_date = date_invoice
+            transaction_date = invoice_date
             if transaction_date >= today:
                 continue
             if partner.cutoff_type == "eom":
@@ -48,7 +48,7 @@ class ResPartner(models.Model):
                 )[-1].date()
             if transaction_date < today:
                 return partner._get_new_invoice_date(today)
-        return date_invoice
+        return invoice_date
 
     @api.model
     def _commercial_fields(self):

--- a/account_invoice_cutoff_policy/tests/test_account_invoice.py
+++ b/account_invoice_cutoff_policy/tests/test_account_invoice.py
@@ -32,7 +32,7 @@ class TestAccountInvoice(common.TransactionCase):
             "%s._get_lock_date" % partner_model, autospec=True
         ) as mock_date:
             mock_date.return_value = new_date
-            invoice._onchange_payment_term_date_invoice()
+            invoice._onchange_invoice_date()
         self.assertEqual(invoice.date_invoice, new_date)
 
     def test_onchange_date_invoice_in(self):
@@ -47,7 +47,7 @@ class TestAccountInvoice(common.TransactionCase):
             "%s._get_lock_date" % partner_model, autospec=True
         ) as mock_date:
             mock_date.return_value = new_date
-            invoice._onchange_payment_term_date_invoice()
+            invoice._onchange_invoice_date()
         self.assertEqual(invoice.date_invoice, orig_date)
 
     def test_onchange_date_invoice_refund(self):
@@ -61,5 +61,5 @@ class TestAccountInvoice(common.TransactionCase):
             "%s._get_lock_date" % partner_model, autospec=True
         ) as mock_date:
             mock_date.return_value = new_date
-            invoice._onchange_payment_term_date_invoice()
+            invoice._onchange_invoice_date()
         self.assertEqual(invoice.date_invoice, new_date)

--- a/account_invoice_cutoff_policy/tests/test_account_invoice.py
+++ b/account_invoice_cutoff_policy/tests/test_account_invoice.py
@@ -20,46 +20,46 @@ class TestAccountInvoice(common.TransactionCase):
         super().setUp()
         self.partner = self.env.ref("base.res_partner_1")
 
-    def test_onchange_date_invoice(self):
+    def test_onchange_invoice_date(self):
         invoice = self.env["account.move"].new()
         invoice.type = "out_invoice"
         invoice.partner_id = self.partner
 
         orig_date = spt("2008-08-03", DEFAULT_SERVER_DATE_FORMAT).date()
         new_date = spt("2012-12-24", DEFAULT_SERVER_DATE_FORMAT).date()
-        invoice.date_invoice = orig_date
+        invoice.invoice_date = orig_date
         with mock.patch(
             "%s._get_lock_date" % partner_model, autospec=True
         ) as mock_date:
             mock_date.return_value = new_date
             invoice._onchange_invoice_date()
-        self.assertEqual(invoice.date_invoice, new_date)
+        self.assertEqual(invoice.invoice_date, new_date)
 
-    def test_onchange_date_invoice_in(self):
+    def test_onchange_invoice_date_in(self):
         invoice = self.env["account.move"].new()
         invoice.type = "in_invoice"
         invoice.partner_id = self.partner
 
         orig_date = spt("2008-08-03", DEFAULT_SERVER_DATE_FORMAT).date()
         new_date = spt("2012-12-24", DEFAULT_SERVER_DATE_FORMAT).date()
-        invoice.date_invoice = orig_date
+        invoice.invoice_date = orig_date
         with mock.patch(
             "%s._get_lock_date" % partner_model, autospec=True
         ) as mock_date:
             mock_date.return_value = new_date
             invoice._onchange_invoice_date()
-        self.assertEqual(invoice.date_invoice, orig_date)
+        self.assertEqual(invoice.invoice_date, orig_date)
 
-    def test_onchange_date_invoice_refund(self):
+    def test_onchange_invoice_date_refund(self):
         invoice = self.env["account.move"].new()
         invoice.type = "out_refund"
         invoice.partner_id = self.partner
         orig_date = spt("2008-08-03", DEFAULT_SERVER_DATE_FORMAT).date()
         new_date = spt("2012-12-24", DEFAULT_SERVER_DATE_FORMAT).date()
-        invoice.date_invoice = orig_date
+        invoice.invoice_date = orig_date
         with mock.patch(
             "%s._get_lock_date" % partner_model, autospec=True
         ) as mock_date:
             mock_date.return_value = new_date
             invoice._onchange_invoice_date()
-        self.assertEqual(invoice.date_invoice, new_date)
+        self.assertEqual(invoice.invoice_date, new_date)

--- a/account_invoice_cutoff_policy/tests/test_account_invoice.py
+++ b/account_invoice_cutoff_policy/tests/test_account_invoice.py
@@ -1,10 +1,12 @@
 # Copyright 2017 Graeme Gellatly
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from datetime import datetime
+
 import mock
+
 from odoo.tests import common
 from odoo.tools.misc import DEFAULT_SERVER_DATE_FORMAT
-from datetime import datetime
 
 partner_model = (
     "odoo.addons.account_invoice_cutoff_policy.models.res_partner.ResPartner"
@@ -19,7 +21,7 @@ class TestAccountInvoice(common.TransactionCase):
         self.partner = self.env.ref("base.res_partner_1")
 
     def test_onchange_date_invoice(self):
-        invoice = self.env["account.invoice"].new()
+        invoice = self.env["account.move"].new()
         invoice.type = "out_invoice"
         invoice.partner_id = self.partner
 
@@ -34,7 +36,7 @@ class TestAccountInvoice(common.TransactionCase):
         self.assertEqual(invoice.date_invoice, new_date)
 
     def test_onchange_date_invoice_in(self):
-        invoice = self.env["account.invoice"].new()
+        invoice = self.env["account.move"].new()
         invoice.type = "in_invoice"
         invoice.partner_id = self.partner
 
@@ -49,7 +51,7 @@ class TestAccountInvoice(common.TransactionCase):
         self.assertEqual(invoice.date_invoice, orig_date)
 
     def test_onchange_date_invoice_refund(self):
-        invoice = self.env["account.invoice"].new()
+        invoice = self.env["account.move"].new()
         invoice.type = "out_refund"
         invoice.partner_id = self.partner
         orig_date = spt("2008-08-03", DEFAULT_SERVER_DATE_FORMAT).date()


### PR DESCRIPTION
Changes:

* Changed all references of account.invoice to account.move
* Changed all references of date_invoice to invoice_date
* Changed _onchange_payment_term_date_invoice to _onchange_invoice_date
* Confirmed tests work as intended (i.e. tests will fail if _onchange is not called)

In v13, "_onchange_payment_term_date_invoice" has been removed. There is no equivalent replacement to this function, but _onchange_invoice_date maintains part of it.