### PR TITLE
[MIG] account_financial_risk_manager: Migration to 13.0

### DIFF
--- a/account_financial_risk_manager/__manifest__.py
+++ b/account_financial_risk_manager/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Account Financial Risk Manager",
     "summary": """
         Adds a seperate security group for managing credit releases""",
-    "version": "12.0.1.0.0",
+    "version": "13.0.1.0.0",
     "license": "AGPL-3",
     "author": "Graeme Gellatly",
     "website": "https://o4sb.com",

--- a/account_financial_risk_manager/views/res_partner_view.xml
+++ b/account_financial_risk_manager/views/res_partner_view.xml
@@ -7,17 +7,6 @@
         <field name="groups_id" eval="[(4, ref('account_financial_risk_manager.group_risk_manager'))]"/>
     </record>
 
-    <record id="account_invoice_confirm_view" model="ir.ui.view">
-        <field name="name">account.invoice.confirm.form (in account_financial_risk_manager)</field>
-        <field name="model">account.invoice.confirm</field>
-        <field name="inherit_id" ref="account_financial_risk.account_invoice_confirm_view" />
-        <field name="arch" type="xml">
-            <xpath expr="//button[@name='invoice_confirm'][@groups='account.group_account_manager']" position="attributes">
-                <attribute name="groups">account_financial_risk_manager.group_risk_manager</attribute>
-            </xpath>
-        </field>
-    </record>
-
     <record id="partner_risk_exceeded_wizard" model="ir.ui.view">
         <field name="name">Partner risk exceeded</field>
         <field name="model">partner.risk.exceeded.wiz</field>


### PR DESCRIPTION
Removed account.invoice.confirm.form (in account_financial_risk_manager) from res_partner_view.

In 13.0 of the account_financial_risk_manager module, account.invoice.confirm.form has been removed with no equivalent replacement.