### PR TITLE
[New] Module to glue account_central_billing and account_invoice_cutoff_policy

### DIFF
--- a/acb_aic_glue/__init__.py
+++ b/acb_aic_glue/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2020 Jonathan Zong
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/acb_aic_glue/__manifest__.py
+++ b/acb_aic_glue/__manifest__.py
@@ -9,5 +9,6 @@
     "website": "https://o4sb.com",
     "depends": ["account_central_billing", "account_invoice_cutoff_policy"],
     "auto_install": True,
-    "summary": "This module is automatically installed if  ",
+    "summary": "This module is automatically installed if account_central_billing and "
+    "account_invoice_cutoff_policy",
 }

--- a/acb_aic_glue/__manifest__.py
+++ b/acb_aic_glue/__manifest__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Jonathan Zong
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Account Central Billing & Account Invoice Cutoff Glue",
+    "version": "13.0.1.1.0",
+    "license": "AGPL-3",
+    "author": "Open For Small Business Ltd",
+    "website": "https://o4sb.com",
+    "depends": ["account_central_billing", "account_invoice_cutoff_policy"],
+    "auto_install": True,
+    "summary": "This module is automatically installed if  ",
+}

--- a/acb_aic_glue/models/__init__.py
+++ b/acb_aic_glue/models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2020 Jonathan Zong
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import account_invoice

--- a/acb_aic_glue/models/account_invoice.py
+++ b/acb_aic_glue/models/account_invoice.py
@@ -1,0 +1,18 @@
+# Copyright 2017 Graeme Gellatly
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AccountInvoice(models.Model):
+    """inherits account.move and adds _get_invoice_partner function"""
+
+    _inherit = "account.move"
+
+    def _get_invoice_partner(self):
+        """
+        Hook method for extensibility to determine which partner should be used
+        for checking the lock date
+        :return: A res.partner recordset
+        """
+        return super()._get_invoice_partner() + self.order_partner_id


### PR DESCRIPTION
_get_invoice_partner() from account_central_billing adds to and relies on account_invoice_cutoff_policy, so this module brings in the added functionality if both modules are installed.