### PR TITLE
[MIG] account_journal_lock_policy to v13

### DIFF
--- a/account_journal_lock_policy/__manifest__.py
+++ b/account_journal_lock_policy/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Accounting Journal Lock Policy",
     "summary": "Specify journal specific lock policies",
-    "version": "12.0.1.1.0",
+    "version": "13.0.0.1.0",
     "license": "AGPL-3",
     "author": "Open For Small Business Ltd",
     "website": "https://o4sb.com",

--- a/account_journal_lock_policy/models/account_journal.py
+++ b/account_journal_lock_policy/models/account_journal.py
@@ -6,7 +6,7 @@ from builtins import range
 from dateutil.relativedelta import relativedelta
 from dateutil.rrule import DAILY, rrule
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class AccountJournal(models.Model):
@@ -21,7 +21,6 @@ class AccountJournal(models.Model):
         [("date", "transaction date"), ("eom", "end of month following transaction")]
     )
 
-    @api.multi
     def _is_locked(self, transaction_date):
         self.ensure_one()
         if not self.enforce_lock:

--- a/account_journal_lock_policy/models/account_move.py
+++ b/account_journal_lock_policy/models/account_move.py
@@ -1,16 +1,15 @@
 # Copyright 2017 Graeme Gellatly
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, models, _
+from odoo import _, models
 from odoo.exceptions import UserError
 
 
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    @api.multi
-    def _check_lock_date(self):
-        res = super()._check_lock_date()
+    def _check_fiscalyear_lock_date(self):
+        res = super()._check_fiscalyear_lock_date()
         for move in self:
             locked = move.journal_id._is_locked(move.date)
             if locked:

--- a/account_journal_lock_policy/tests/test_account_move.py
+++ b/account_journal_lock_policy/tests/test_account_move.py
@@ -2,10 +2,9 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import mock
-from odoo.tests import common
 
 from odoo.exceptions import UserError
-
+from odoo.tests import common
 
 module = (
     "odoo.addons.account_journal_lock_policy.models." "account_journal.AccountJournal"
@@ -34,4 +33,4 @@ class TestAccountMove(common.TransactionCase):
                         "company_id": company_id,
                     }
                 )
-                move._check_lock_date()
+                move._check_fiscalyear_lock_date()


### PR DESCRIPTION
Replaced _check_lock_date() with _check_fiscalyear_lock_date().
_check_lock_date() has been removed from the account.move model, with _check_fiscalyear_lock_date() as an equivalent replacement.