### PR TITLE
[MIG] auth_oauth_microsoft_graph: Migration to 16.0

### DIFF
--- a/auth_oauth_microsoft_graph/README.rst
+++ b/auth_oauth_microsoft_graph/README.rst
@@ -1,0 +1,80 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+====================================
+Microsoft Graph OAuth Authentication
+====================================
+
+Allows users to login using Microsoft Graph in Azure AD environments.
+The only purpose of this module is to set the name, email address and
+username of a user signing in for the first time.
+
+Installation
+============
+
+This module will define the system parameter `auth_oauth.authorization_header`, which tells Odoo
+to include the Bearer token in the Authorization header instead of passing the access token
+as a parameter. If some other OAuth2 methods have already been configured, this parameter might
+interfere with them.
+
+Configuration
+=============
+
+If using B2B authentication you will need to populate users
+authentication usernames and complete an oauth provider.
+
+- Provider name: AzureAD
+- Client ID: <Client ID provided when registering Application>
+- Body: Login with Microsoft
+- Auth URL: https://login.microsoftonline.com/common/oauth2/v2.0/authorize
+- Scope: User.Read User.ReadBasic.All
+- Validation URL: https://graph.microsoft.com/v1.0/me
+- Data URL: <Empty>
+
+The configuration in Azure APP:
+
+- Enable multi-tenanted in Azure App - setting - properties
+- Required permissions - Windows Azure Active Directory - Grant permissions - Sign in and read user profile, Sign in and read user profile , Access the directory as the signed-in user
+- Required permissions - Microsoft Graph - Grant permissions - Access the directory as the signed-in user, Sign users in , View users' email address
+- Edit manifest - "oauth2AllowImplicitFlow": true,
+- Redirect URL: https://<yourodoopublicdomain>/auth_oauth/signin
+
+If you like to enable user to signup, just turn on the B2C login in odoo - setting - Users - Customer Account
+
+Usage
+=====
+
+- Prior to first login, user must exist in Odoo if signup not enabled. You must also "Send an invitation" to reset password which user must complete.
+- User selects Login with Microsoft at login screen to authenticate.
+
+Known issues / Roadmap
+======================
+
+Ideally this module shouldn't be required and will be deprecated
+as soon as Odoo supports AZUREAD logins.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/odoonz/account/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Graeme Gellatly <graeme@o4sb.com>
+* Chris Mann <https://github.com/chrisandrewmann>
+* Miku Laitinen <https://github.com/mlaitinen>
+
+Maintainer
+----------
+
+This module is maintained by Open for Small Business Ltd.
+
+Open for Small Business is a small developer and integrator of Odoo software since 2009.

--- a/auth_oauth_microsoft_graph/__init__.py
+++ b/auth_oauth_microsoft_graph/__init__.py
@@ -1,0 +1,9 @@
+from . import models
+
+from odoo import api, SUPERUSER_ID
+
+
+def post_init(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    # To make Odoo include the Bearer token in the Authorization header, this parameter has to be set
+    env["ir.config_parameter"].set_param("auth_oauth.authorization_header", "1")

--- a/auth_oauth_microsoft_graph/__manifest__.py
+++ b/auth_oauth_microsoft_graph/__manifest__.py
@@ -1,0 +1,13 @@
+# Copyright 2017 Graeme Gellatly
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Microsoft Graph Oauth Authentication",
+    "version": "16.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "Open For Small Business Ltd",
+    "website": "https://o4sb.com",
+    "summary": "Allow users to login using Microsoft Graph.",
+    "depends": ["auth_oauth"],
+    "post_init_hook": "post_init",
+}

--- a/auth_oauth_microsoft_graph/models/__init__.py
+++ b/auth_oauth_microsoft_graph/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_users

--- a/auth_oauth_microsoft_graph/models/res_users.py
+++ b/auth_oauth_microsoft_graph/models/res_users.py
@@ -1,0 +1,16 @@
+# Copyright 2017 Graeme Gellatly
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models, api
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    @api.model
+    def _generate_signup_values(self, provider, validation, params):
+        values = super()._generate_signup_values(provider, validation, params)
+        values["email"] = validation.get("userPrincipalName", values["email"])
+        values["login"] = values["email"]
+        values["name"] = validation.get("displayName", values["email"])
+        return values


### PR DESCRIPTION
Odoo 16.0 is [capable of adding the `Authorization` header](https://github.com/odoo/odoo/blob/04d11bf763068dabedc667266e1a6adf0b5db8c0/addons/auth_oauth/models/res_users.py#L29) when the system parameter `auth_oauth.authorization_header` is set. So Odoo partially supports this authentication method, but without this module the logged in user will have an autogenerated name, email and username.